### PR TITLE
Fix issue #14 to add support for library-specific config files

### DIFF
--- a/examples/directory-browser/src/main/webapp/WEB-INF/teaservlet.xml
+++ b/examples/directory-browser/src/main/webapp/WEB-INF/teaservlet.xml
@@ -41,67 +41,6 @@
 	
     <applications>
 
-		<!-- 
-		load the standard TeaServlet administration console and methods
-		-->
-		
-        <TeaServletAdmin>
-            <class>org.teatrove.teaservlet.AdminApplication</class>
-        </TeaServletAdmin>
-        
-        <!-- 
-        load the main applications required by the admin interface
-        -->
-        
-        <StringApplication>
-            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
-            <init>
-                <contextClass>org.teatrove.teaapps.contexts.StringContext</contextClass>
-            </init>
-        </StringApplication>
-
-        <ListApplication>
-            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
-            <init>
-                <contextClass>org.teatrove.teaapps.contexts.ListContext</contextClass>
-            </init>
-        </ListApplication>
-                
-        <MapApplication>
-            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
-            <init>
-                <contextClass>org.teatrove.teaapps.contexts.MapContext</contextClass>
-            </init>
-        </MapApplication>
-        
-        <DateApplication>
-            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
-            <init>
-                <contextClass>org.teatrove.teaapps.contexts.DateContext</contextClass>
-            </init>
-        </DateApplication>
-        
-        <MathApplication>
-            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
-            <init>
-                <contextClass>org.teatrove.teaapps.contexts.MathContext</contextClass>
-            </init>
-        </MathApplication>
-        
-        <NumberFormatApplication>
-            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
-            <init>
-                <contextClass>org.teatrove.teaapps.contexts.NumberFormatContext</contextClass>
-            </init>
-        </NumberFormatApplication>
-        
-        <JMXApplication>
-            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
-            <init>
-                <contextClass>org.teatrove.teaapps.contexts.JMXContext</contextClass>
-            </init>
-        </JMXApplication>
-        
         <!-- 
         load our custom DirectoryBrowserApplication that provides access to
         functionality to traverse a directory structure.  The <init> block may 

--- a/examples/directory-browser/src/main/webapp/WEB-INF/web.xml
+++ b/examples/directory-browser/src/main/webapp/WEB-INF/web.xml
@@ -9,7 +9,7 @@
         <init-param>
             <param-name>properties.file</param-name>
             <param-value>/WEB-INF/teaservlet.xml</param-value>
-        </init-param>
+        </init-param>        
         <load-on-startup>1</load-on-startup>
     </servlet>
 

--- a/examples/hello-world/src/main/webapp/WEB-INF/teaservlet.xml
+++ b/examples/hello-world/src/main/webapp/WEB-INF/teaservlet.xml
@@ -1,25 +1,6 @@
 <teaservlet>
 
 	<!-- 
-	define the default template when just the directory is provided 
-	-->
-    
-    <template>
-        <default>index</default>
-    </template>
-
-	<!-- 
-	define the logging states for the TeaServlet 
-	-->
-    
-    <log>
-        <debug>false</debug>
-        <info>true</info>
-        <warn>true</warn>
-        <error>true</error>
-    </log>
-
-	<!-- 
 	define the administration key required to access the administration pages
 	ie: http://[host]:[port]/[context]/system/teaservlet/Admin?[key]=[value]
 	-->
@@ -40,67 +21,6 @@
 	-->
 	
     <applications>
-
-		<!-- 
-		load the standard TeaServlet administration console and methods
-		-->
-		
-        <TeaServletAdmin>
-            <class>org.teatrove.teaservlet.AdminApplication</class>
-        </TeaServletAdmin>
-
-        <!-- 
-        load the main applications required by the admin interface
-        -->
-        
-        <StringApplication>
-            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
-            <init>
-                <contextClass>org.teatrove.teaapps.contexts.StringContext</contextClass>
-            </init>
-        </StringApplication>
-
-        <ListApplication>
-            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
-            <init>
-                <contextClass>org.teatrove.teaapps.contexts.ListContext</contextClass>
-            </init>
-        </ListApplication>
-                
-        <MapApplication>
-            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
-            <init>
-                <contextClass>org.teatrove.teaapps.contexts.MapContext</contextClass>
-            </init>
-        </MapApplication>
-        
-        <DateApplication>
-            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
-            <init>
-                <contextClass>org.teatrove.teaapps.contexts.DateContext</contextClass>
-            </init>
-        </DateApplication>
-        
-        <MathApplication>
-            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
-            <init>
-                <contextClass>org.teatrove.teaapps.contexts.MathContext</contextClass>
-            </init>
-        </MathApplication>
-        
-        <NumberFormatApplication>
-            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
-            <init>
-                <contextClass>org.teatrove.teaapps.contexts.NumberFormatContext</contextClass>
-            </init>
-        </NumberFormatApplication>
-        
-        <JMXApplication>
-            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
-            <init>
-                <contextClass>org.teatrove.teaapps.contexts.JMXContext</contextClass>
-            </init>
-        </JMXApplication>
                 
         <!-- 
         load our custom HelloWorldApplication that provides access and registers

--- a/examples/hello-world/src/main/webapp/WEB-INF/web.xml
+++ b/examples/hello-world/src/main/webapp/WEB-INF/web.xml
@@ -6,10 +6,6 @@
     <servlet>
         <servlet-name>TeaServlet</servlet-name>
         <servlet-class>org.teatrove.teaservlet.TeaServlet</servlet-class>
-        <init-param>
-            <param-name>properties.file</param-name>
-            <param-value>/WEB-INF/teaservlet.xml</param-value>
-        </init-param>
         <load-on-startup>1</load-on-startup>
     </servlet>
 

--- a/teaadmin/src/main/resources/META-INF/teaservlet.xml
+++ b/teaadmin/src/main/resources/META-INF/teaservlet.xml
@@ -1,0 +1,12 @@
+<teaservlet>
+	
+    <!-- define list of administration applications -->
+    <applications>
+
+        <TeaServletAdmin>
+            <class>org.teatrove.teaservlet.AdminApplication</class>
+        </TeaServletAdmin>
+
+    </applications>
+
+</teaservlet>

--- a/teaapps/src/main/resources/META-INF/teaservlet.xml
+++ b/teaapps/src/main/resources/META-INF/teaservlet.xml
@@ -1,0 +1,156 @@
+<teaservlet>
+	
+    <!-- define list of default applications -->
+    <applications>
+
+        <CaptureApplication>
+            <class>org.teatrove.teaapps.apps.CaptureApplication</class>
+        </CaptureApplication>
+
+        <ThrowableCatcherApplication>
+            <class>org.teatrove.teaapps.apps.ThrowableCatcherApplication</class>
+        </ThrowableCatcherApplication>
+        
+        <ArrayApplication>
+            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
+            <init>
+                <contextClass>org.teatrove.teaapps.contexts.ArrayContext</contextClass>
+            </init>
+        </ArrayApplication>
+        
+        <BeanApplication>
+            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
+            <init>
+                <contextClass>org.teatrove.teaapps.contexts.BeanContext</contextClass>
+            </init>
+        </BeanApplication>
+        
+        <CastApplication>
+            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
+            <init>
+                <contextClass>org.teatrove.teaapps.contexts.CastContext</contextClass>
+            </init>
+        </CastApplication>
+        
+        <CryptoApplication>
+            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
+            <init>
+                <contextClass>org.teatrove.teaapps.contexts.CryptoContext</contextClass>
+            </init>
+        </CryptoApplication>
+        
+        <DateApplication>
+            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
+            <init>
+                <contextClass>org.teatrove.teaapps.contexts.DateContext</contextClass>
+            </init>
+        </DateApplication>
+        
+        <EncodingApplication>
+            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
+            <init>
+                <contextClass>org.teatrove.teaapps.contexts.EncodingContext</contextClass>
+            </init>
+        </EncodingApplication>
+        
+        <FileSystemApplication>
+            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
+            <init>
+                <contextClass>org.teatrove.teaapps.contexts.FileSystemContext</contextClass>
+            </init>
+        </FileSystemApplication>
+        
+        <HttpApplication>
+            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
+            <init>
+                <contextClass>org.teatrove.teaapps.contexts.HttpContext</contextClass>
+            </init>
+        </HttpApplication>
+        
+        <JMXApplication>
+            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
+            <init>
+                <contextClass>org.teatrove.teaapps.contexts.JMXContext</contextClass>
+            </init>
+        </JMXApplication>
+        
+        <ListApplication>
+            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
+            <init>
+                <contextClass>org.teatrove.teaapps.contexts.ListContext</contextClass>
+            </init>
+        </ListApplication>
+        
+        <MapApplication>
+            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
+            <init>
+                <contextClass>org.teatrove.teaapps.contexts.MapContext</contextClass>
+            </init>
+        </MapApplication>
+        
+        <MathApplication>
+            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
+            <init>
+                <contextClass>org.teatrove.teaapps.contexts.MathContext</contextClass>
+            </init>
+        </MathApplication>
+        
+        <NumberFormatApplication>
+            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
+            <init>
+                <contextClass>org.teatrove.teaapps.contexts.NumberFormatContext</contextClass>
+            </init>
+        </NumberFormatApplication>
+        
+        <ObjectCacheApplication>
+            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
+            <init>
+                <contextClass>org.teatrove.teaapps.contexts.ObjectCacheContext</contextClass>
+            </init>
+        </ObjectCacheApplication>
+        
+        <PluginAccessorApplication>
+            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
+            <init>
+                <contextClass>org.teatrove.teaapps.contexts.PluginAccessorContext</contextClass>
+            </init>
+        </PluginAccessorApplication>
+        
+        <RandomApplication>
+            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
+            <init>
+                <contextClass>org.teatrove.teaapps.contexts.RandomContext</contextClass>
+            </init>
+        </RandomApplication>
+        
+        <SetApplication>
+            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
+            <init>
+                <contextClass>org.teatrove.teaapps.contexts.SetContext</contextClass>
+            </init>
+        </SetApplication>
+        
+        <SortApplication>
+            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
+            <init>
+                <contextClass>org.teatrove.teaapps.contexts.SortContext</contextClass>
+            </init>
+        </SortApplication>
+        
+        <StringApplication>
+            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
+            <init>
+                <contextClass>org.teatrove.teaapps.contexts.StringContext</contextClass>
+            </init>
+        </StringApplication>
+        
+        <TemplateExceptionApplication>
+            <class>org.teatrove.teaapps.apps.DefaultApplication</class>
+            <init>
+                <contextClass>org.teatrove.teaapps.contexts.TemplateExceptionContext</contextClass>
+            </init>
+        </TemplateExceptionApplication>
+                
+    </applications>
+
+</teaservlet>

--- a/teaservlet/src/main/java/org/teatrove/teaservlet/TeaServlet.java
+++ b/teaservlet/src/main/java/org/teatrove/teaservlet/TeaServlet.java
@@ -29,8 +29,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;

--- a/teaservlet/src/main/resources/META-INF/teaservlet.xml
+++ b/teaservlet/src/main/resources/META-INF/teaservlet.xml
@@ -1,0 +1,22 @@
+<teaservlet>
+
+    <!-- 
+    define the default template when just the directory is provided 
+    -->
+    
+    <template>
+        <default>index</default>
+    </template>
+
+    <!-- 
+    define the logging states for the TeaServlet 
+    -->
+    
+    <log>
+        <debug>false</debug>
+        <info>true</info>
+        <warn>true</warn>
+        <error>true</error>
+    </log>
+
+</teaservlet>

--- a/trove/src/main/java/org/teatrove/trove/util/plugin/PluginContext.java
+++ b/trove/src/main/java/org/teatrove/trove/util/plugin/PluginContext.java
@@ -155,6 +155,20 @@ public class PluginContext implements ResourceFactory {
      * {@inheritDoc}
      */
     @Override
+    public PropertyMap getResourceAsProperties(String path, InputStream input) 
+        throws IOException {
+        
+        if (mResourceFactory == null) {
+            return null;
+        }
+        
+        return mResourceFactory.getResourceAsProperties(path, input);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public PropertyMap getResourceAsProperties(String path, 
                                                PropertyMap substitutions)
         throws IOException {
@@ -164,6 +178,22 @@ public class PluginContext implements ResourceFactory {
         }
         
         return mResourceFactory.getResourceAsProperties(path, substitutions);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PropertyMap getResourceAsProperties(String path, InputStream input,
+                                               PropertyMap substitutions)
+        throws IOException {
+        
+        if (mResourceFactory == null) {
+            return null;
+        }
+        
+        return mResourceFactory.getResourceAsProperties(path, input,
+                                                        substitutions);
     }
     
     /* Notifies all PluginListeners of a Plugin being added to this class.

--- a/trove/src/main/java/org/teatrove/trove/util/resources/DefaultResourceFactory.java
+++ b/trove/src/main/java/org/teatrove/trove/util/resources/DefaultResourceFactory.java
@@ -56,6 +56,7 @@ public class DefaultResourceFactory implements ResourceFactory {
     /**
      * {@inheritDoc}
      */
+    @Override
     public URL getResource(String path)
         throws MalformedURLException {
         
@@ -71,6 +72,7 @@ public class DefaultResourceFactory implements ResourceFactory {
     /**
      * {@inheritDoc}
      */
+    @Override
     public InputStream getResourceAsStream(String path) {
         try { return new FileInputStream(path); }
         catch (FileNotFoundException fnfe) {
@@ -81,6 +83,7 @@ public class DefaultResourceFactory implements ResourceFactory {
     /**
      * {@inheritDoc}
      */
+    @Override
     public PropertyMap getResourceAsProperties(String path) 
         throws IOException {
         
@@ -90,12 +93,38 @@ public class DefaultResourceFactory implements ResourceFactory {
     /**
      * {@inheritDoc}
      */
+    @Override
+    public PropertyMap getResourceAsProperties(String path, InputStream input) 
+        throws IOException {
+    
+        return getResourceAsProperties(path, input,
+                                       SubstitutionFactory.getDefaults());
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public PropertyMap getResourceAsProperties(String path, 
                                                PropertyMap substitutions)
         throws IOException {
         
         // get associated resource
         InputStream input = getResourceAsStream(path);
+        if (input == null) { return null; }
+        
+        // lookup properties
+        return getResourceAsProperties(path, input, substitutions);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PropertyMap getResourceAsProperties(String path, InputStream input,
+                                               PropertyMap substitutions)
+        throws IOException {
+        
         if (input == null) { return null; }
         Reader reader = new InputStreamReader(input);
         

--- a/trove/src/main/java/org/teatrove/trove/util/resources/ResourceFactory.java
+++ b/trove/src/main/java/org/teatrove/trove/util/resources/ResourceFactory.java
@@ -73,6 +73,26 @@ public interface ResourceFactory {
     
     /**
      * Get the associated resource as a {@link PropertyMap} per the specified
+     * path.  This will load the resource per the given input stream and
+     * if the resource is not valid, then <code>null</code> is returned.  By
+     * default, any properties will be auto-substituted by the default
+     * substitutions per {@link SubstitutionFactory#getDefaults()}.  The type of
+     * resource is determined by the path.  For examples, 'properties' files
+     * use a properties resource loader whereas 'xml' files use a XML resource
+     * loader.  For more information, see {@link PropertyMapFactoryProvider}.
+     * 
+     * @param path  The name or path of the resource
+     * @param input  The associated stream to load
+     * 
+     * @return  The associated list of properties
+     * 
+     * @throws IOException   If an error occurs loading or parsing the resource
+     */
+    PropertyMap getResourceAsProperties(String path, InputStream input) 
+        throws IOException;
+    
+    /**
+     * Get the associated resource as a {@link PropertyMap} per the specified
      * path.  This will load the resource per {@link #getResource(String)} and
      * if the resource is not valid, then <code>null</code> is returned.  Any 
      * properties will be auto-substituted by the specified substitutions.  The
@@ -89,5 +109,26 @@ public interface ResourceFactory {
      * @throws IOException   If an error occurs loading or parsing the resource
      */
     PropertyMap getResourceAsProperties(String path, PropertyMap substitutions)
+        throws IOException;
+    
+    /**
+     * Get the associated resource as a {@link PropertyMap} per the specified
+     * path.  This will load the resource per the given input stream and
+     * if the resource is not valid, then <code>null</code> is returned.  Any 
+     * properties will be auto-substituted by the specified substitutions.  The
+     * type of resource is determined by the path.  For examples, 'properties' 
+     * files use a properties resource loader whereas 'xml' files use a XML 
+     * resource loader.  For more information, see 
+     * {@link PropertyMapFactoryProvider}.
+     * 
+     * @param path  The name or path of the resource
+     * @param substitutions  The map of substitutions to replace properties with
+     * 
+     * @return  The associated list of properties
+     * 
+     * @throws IOException   If an error occurs loading or parsing the resource
+     */
+    PropertyMap getResourceAsProperties(String path, InputStream input,
+                                        PropertyMap substitutions)
         throws IOException;
 }


### PR DESCRIPTION
Updated TeaServlet to load any /META-INF/teaservlet.xml or /META-INF/teaservlet.properties from any library within the deployed application.  The properties are only added as defaults and do not overwrite existing properties.  Also added ability to merge template.paths between multiple libraries so they are aggregated together.

The teaadmin, teaapps, and teaservlet have initial configs provided
