### PR TITLE
Bug Fix for compiling templates from remote jar

### DIFF
--- a/tea/src/main/java/org/teatrove/tea/util/JarCompilationProvider.java
+++ b/tea/src/main/java/org/teatrove/tea/util/JarCompilationProvider.java
@@ -146,7 +146,10 @@ public class JarCompilationProvider implements CompilationProvider {
 
         public JarOfTemplates(File file) throws IOException {
             mUrl = makeJarUrlFromFile(file);
+            
             mConn = (JarURLConnection)mUrl.openConnection();
+            mConn.setUseCaches(false);
+            
             mJarFile = mConn.getJarFile();
         }
 


### PR DESCRIPTION
Turned off caching in JarURLConnection so the JarCompilationProvider will not get cached versions of the template jar files.  Using the cached template jar files caused many issues with the tea compiler.
